### PR TITLE
Add unit tests for lead-time calculation and commit traversal

### DIFF
--- a/src/main/java/io/github/arlol/dora/GitDoraLeadTimeCalculatorApplication.java
+++ b/src/main/java/io/github/arlol/dora/GitDoraLeadTimeCalculatorApplication.java
@@ -5,7 +5,8 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.stream.StreamSupport;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -20,9 +21,12 @@ public class GitDoraLeadTimeCalculatorApplication {
 		if (args.length == 1 && "--version".equals(args[0])) {
 			Package pkg = GitDoraLeadTimeCalculatorApplication.class
 					.getPackage();
-			String title = pkg.getImplementationTitle();
-			String version = pkg.getImplementationVersion();
-			System.out.println(title + " version \"" + version + "\"");
+			System.out.println(
+					versionString(
+							pkg.getImplementationTitle(),
+							pkg.getImplementationVersion()
+					)
+			);
 			return;
 		}
 		// dora commitIdOfRelease commitIdOfPreviousRelease
@@ -34,29 +38,62 @@ public class GitDoraLeadTimeCalculatorApplication {
 			var deployInstant = ZonedDateTime.parse(args[2]).toInstant();
 			System.out.println("Deploy time in UTC: " + deployInstant);
 
-			var commits = jgit(startCommit, endCommit, deployInstant);
-			var average = StreamSupport.stream(commits.spliterator(), false)
-					.peek(commit -> {
-						System.out.println(
-								"Considering commit " + commit.getId().getName()
-										+ " with author time of "
-										+ commit.getAuthorIdent()
-												.getWhenAsInstant()
-										+ " and message: "
-										+ commit.getShortMessage()
-						);
-					})
-					.map(commit -> {
-						return Duration.between(
-								commit.getAuthorIdent().getWhenAsInstant(),
-								deployInstant
-						);
-					})
-					.reduce((a, b) -> a.plus(b).dividedBy(2L))
-					.orElse(Duration.ZERO);
+			List<RevCommit> commits = commitsBetween(startCommit, endCommit);
+			List<Instant> authorTimes = new ArrayList<>();
+			for (RevCommit commit : commits) {
+				Instant authorTime = commit.getAuthorIdent().getWhenAsInstant();
+				authorTimes.add(authorTime);
+				System.out.println(
+						"Considering commit " + commit.getId().getName()
+								+ " with author time of " + authorTime
+								+ " and message: " + commit.getShortMessage()
+				);
+			}
+			Duration average = averageLeadTime(authorTimes, deployInstant);
 			System.out.println(
 					"Average between author and deploy times: " + average
 			);
+		}
+	}
+
+	/**
+	 * Formats the {@code --version} output line.
+	 */
+	static String versionString(String title, String version) {
+		return title + " version \"" + version + "\"";
+	}
+
+	/**
+	 * Calculates the average lead time between every commit's author time and
+	 * the deploy time.
+	 *
+	 * <p>
+	 * The commits are folded pairwise, so the result is a running average of
+	 * the shape {@code ((d1 + d2) / 2 + d3) / 2 ...} rather than the arithmetic
+	 * mean. Returns {@link Duration#ZERO} when there are no commits.
+	 */
+	static Duration averageLeadTime(
+			List<Instant> authorTimes,
+			Instant deployInstant
+	) {
+		return authorTimes.stream()
+				.map(authorTime -> Duration.between(authorTime, deployInstant))
+				.reduce((a, b) -> a.plus(b).dividedBy(2L))
+				.orElse(Duration.ZERO);
+	}
+
+	/**
+	 * Resolves the commits reachable from {@code startCommitId} but not from
+	 * {@code endCommitId} in the git repository found via the environment.
+	 */
+	static List<RevCommit> commitsBetween(
+			String startCommitId,
+			String endCommitId
+	) {
+		try (Repository repository = openRepository()) {
+			return commitsBetween(repository, startCommitId, endCommitId);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
 		}
 	}
 
@@ -64,16 +101,23 @@ public class GitDoraLeadTimeCalculatorApplication {
 			value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
 			justification = "FileRepositoryBuilder uses generics which spotbugs cant know"
 	)
-	private static Iterable<RevCommit> jgit(
-			String startCommitId,
-			String endCommitId,
-			Instant deployInstant
-	) {
-		try (Repository repository = new FileRepositoryBuilder()
-				.setMustExist(true)
+	private static Repository openRepository() throws IOException {
+		return new FileRepositoryBuilder().setMustExist(true)
 				.readEnvironment()
 				.findGitDir()
-				.build(); RevWalk revWalk = new RevWalk(repository);) {
+				.build();
+	}
+
+	/**
+	 * Resolves the commits reachable from {@code startCommitId} but not from
+	 * {@code endCommitId} in the given repository.
+	 */
+	static List<RevCommit> commitsBetween(
+			Repository repository,
+			String startCommitId,
+			String endCommitId
+	) {
+		try (RevWalk revWalk = new RevWalk(repository)) {
 			RevCommit startCommit = revWalk
 					.parseCommit(repository.resolve(startCommitId));
 			RevCommit endCommit = revWalk
@@ -90,7 +134,12 @@ public class GitDoraLeadTimeCalculatorApplication {
 
 			revWalk.markStart(startCommit);
 			revWalk.markUninteresting(endCommit);
-			return revWalk;
+
+			List<RevCommit> commits = new ArrayList<>();
+			for (RevCommit commit : revWalk) {
+				commits.add(commit);
+			}
+			return commits;
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}

--- a/src/main/java/io/github/arlol/dora/GitDoraLeadTimeCalculatorApplication.java
+++ b/src/main/java/io/github/arlol/dora/GitDoraLeadTimeCalculatorApplication.java
@@ -13,8 +13,6 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class GitDoraLeadTimeCalculatorApplication {
 
 	public static void main(String[] args) {
@@ -97,10 +95,6 @@ public class GitDoraLeadTimeCalculatorApplication {
 		}
 	}
 
-	@SuppressFBWarnings(
-			value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-			justification = "FileRepositoryBuilder uses generics which spotbugs cant know"
-	)
 	private static Repository openRepository() throws IOException {
 		return new FileRepositoryBuilder().setMustExist(true)
 				.readEnvironment()

--- a/src/test/java/io/github/arlol/dora/CommitsBetweenTests.java
+++ b/src/test/java/io/github/arlol/dora/CommitsBetweenTests.java
@@ -1,0 +1,121 @@
+package io.github.arlol.dora;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CommitsBetweenTests {
+
+	@TempDir
+	Path repositoryDir;
+
+	@Test
+	void returnsCommitsReachableFromStartButNotFromEnd() throws Exception {
+		try (Git git = Git.init().setDirectory(repositoryDir.toFile()).call()) {
+			RevCommit base = commit(git, "base");
+			RevCommit middle = commit(git, "middle");
+			RevCommit head = commit(git, "head");
+
+			List<String> result = names(
+					GitDoraLeadTimeCalculatorApplication.commitsBetween(
+							git.getRepository(),
+							head.getName(),
+							base.getName()
+					)
+			);
+
+			assertEquals(List.of(head.getName(), middle.getName()), result);
+		}
+	}
+
+	@Test
+	void returnsSingleCommitForAdjacentRange() throws Exception {
+		try (Git git = Git.init().setDirectory(repositoryDir.toFile()).call()) {
+			RevCommit previous = commit(git, "previous");
+			RevCommit release = commit(git, "release");
+
+			List<String> result = names(
+					GitDoraLeadTimeCalculatorApplication.commitsBetween(
+							git.getRepository(),
+							release.getName(),
+							previous.getName()
+					)
+			);
+
+			assertEquals(List.of(release.getName()), result);
+		}
+	}
+
+	@Test
+	void isEmptyWhenStartIsReachableFromEnd() throws Exception {
+		try (Git git = Git.init().setDirectory(repositoryDir.toFile()).call()) {
+			RevCommit previous = commit(git, "previous");
+			commit(git, "release");
+
+			List<String> result = names(
+					GitDoraLeadTimeCalculatorApplication.commitsBetween(
+							git.getRepository(),
+							previous.getName(),
+							previous.getName()
+					)
+			);
+
+			assertEquals(List.of(), result);
+		}
+	}
+
+	@Test
+	void preservesAuthorTimes() throws Exception {
+		Instant authored = Instant.parse("2024-01-15T10:00:00Z");
+		try (Git git = Git.init().setDirectory(repositoryDir.toFile()).call()) {
+			RevCommit base = commit(git, "base");
+			commitAt(git, "release", authored);
+
+			Repository repository = git.getRepository();
+			List<RevCommit> commits = GitDoraLeadTimeCalculatorApplication
+					.commitsBetween(repository, "HEAD", base.getName());
+
+			assertEquals(1, commits.size());
+			assertEquals(
+					authored,
+					commits.get(0).getAuthorIdent().getWhenAsInstant()
+			);
+		}
+	}
+
+	private static RevCommit commit(Git git, String message) throws Exception {
+		return commitAt(git, message, Instant.parse("2024-01-01T00:00:00Z"));
+	}
+
+	private static RevCommit commitAt(Git git, String message, Instant when)
+			throws Exception {
+		PersonIdent ident = new PersonIdent(
+				"Tester",
+				"tester@example.com",
+				when,
+				ZoneOffset.UTC
+		);
+		return git.commit()
+				.setMessage(message)
+				.setAllowEmpty(true)
+				.setSign(false)
+				.setAuthor(ident)
+				.setCommitter(ident)
+				.call();
+	}
+
+	private static List<String> names(List<RevCommit> commits) {
+		return commits.stream().map(RevCommit::getName).toList();
+	}
+
+}

--- a/src/test/java/io/github/arlol/dora/GitDoraLeadTimeCalculatorTests.java
+++ b/src/test/java/io/github/arlol/dora/GitDoraLeadTimeCalculatorTests.java
@@ -1,14 +1,90 @@
 package io.github.arlol.dora;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 public class GitDoraLeadTimeCalculatorTests {
 
+	private static final Instant DEPLOY = Instant.parse("2024-01-15T12:00:00Z");
+
 	@Test
-	public void isTrue() throws Exception {
-		assertTrue(true);
+	public void averageLeadTimeIsZeroWithoutCommits() {
+		assertEquals(
+				Duration.ZERO,
+				GitDoraLeadTimeCalculatorApplication
+						.averageLeadTime(List.of(), DEPLOY)
+		);
+	}
+
+	@Test
+	public void averageLeadTimeOfSingleCommitIsItsLeadTime() {
+		Instant authored = Instant.parse("2024-01-15T10:00:00Z");
+
+		assertEquals(
+				Duration.ofHours(2),
+				GitDoraLeadTimeCalculatorApplication
+						.averageLeadTime(List.of(authored), DEPLOY)
+		);
+	}
+
+	@Test
+	public void averageLeadTimeOfTwoCommitsIsTheirMean() {
+		Instant twoHoursBefore = DEPLOY.minus(Duration.ofHours(2));
+		Instant fourHoursBefore = DEPLOY.minus(Duration.ofHours(4));
+
+		assertEquals(
+				Duration.ofHours(3),
+				GitDoraLeadTimeCalculatorApplication.averageLeadTime(
+						List.of(twoHoursBefore, fourHoursBefore),
+						DEPLOY
+				)
+		);
+	}
+
+	@Test
+	public void averageLeadTimeFoldsCommitsPairwise() {
+		// Three commits are reduced as ((d1 + d2) / 2 + d3) / 2.
+		// d1 = 2h, d2 = 4h, d3 = 6h -> ((2+4)/2 + 6)/2 = (3 + 6)/2 = 4.5h
+		Instant twoHoursBefore = DEPLOY.minus(Duration.ofHours(2));
+		Instant fourHoursBefore = DEPLOY.minus(Duration.ofHours(4));
+		Instant sixHoursBefore = DEPLOY.minus(Duration.ofHours(6));
+
+		assertEquals(
+				Duration.ofMinutes(270),
+				GitDoraLeadTimeCalculatorApplication.averageLeadTime(
+						List.of(
+								twoHoursBefore,
+								fourHoursBefore,
+								sixHoursBefore
+						),
+						DEPLOY
+				)
+		);
+	}
+
+	@Test
+	public void averageLeadTimeIsNegativeWhenAuthoredAfterDeploy() {
+		Instant afterDeploy = DEPLOY.plus(Duration.ofHours(1));
+
+		assertEquals(
+				Duration.ofHours(-1),
+				GitDoraLeadTimeCalculatorApplication
+						.averageLeadTime(List.of(afterDeploy), DEPLOY)
+		);
+	}
+
+	@Test
+	public void versionStringIsFormatted() {
+		assertEquals(
+				"git-dora-lead-time-calculator version \"1.2.3\"",
+				GitDoraLeadTimeCalculatorApplication
+						.versionString("git-dora-lead-time-calculator", "1.2.3")
+		);
 	}
 
 }


### PR DESCRIPTION
Extract the lead-time averaging, version-string formatting, and the
jgit commit traversal from main into package-private static methods so
they can be exercised directly, keeping the runtime behaviour identical.

Add tests covering:
- averageLeadTime: empty, single, two and three commits (pairwise fold),
  and negative lead time when authored after deploy
- versionString formatting
- commitsBetween against a real temporary repository: reachability,
  adjacent range, empty range, and author-time preservation

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JWYFQC1iSj1pxQyASsEwCj